### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ install:
   - pip3 install pipenv
   - pipenv install
 script:
-  - pytest
+  - python -m unittest discover test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+dist: xenial
+language: python
+python:
+  - "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,8 @@ dist: xenial
 language: python
 python:
   - "3.7"
+install:
+  - pip3 install pipenv
+  - pipenv install
+script:
+  - pytest

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **A cross-plaform Python API and daemon for the Envisalink TPI (DSC) module**
 
-**Requirements:** Python >= 3.5 and packages found in requirements.txt file.
+**Requirements:** Python >= 3.7 and packages found in Pipfile & Pipfile.lock.
 
 **Note:** This version is a work in progress and may not be entirely stable and bug-free.
 But it shouldn't melt your system, so there's that.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# EvlDaemon
+# EvlDaemon [![Build Status](https://travis-ci.org/Tokenize/evl-daemon-python.png)](https://travis-ci.org/Tokenize/evl-daemon-python)
 
 **A cross-plaform Python API and daemon for the Envisalink TPI (DSC) module**
 


### PR DESCRIPTION
The Travis config only targets Python 3.7 (for now) but can be modified to support more versions later as needed.